### PR TITLE
refactor(projects): rename school cluster to personal

### DIFF
--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -39,7 +39,7 @@ export interface ProjectDetailContent {
 
 /** Which cluster a project belongs to — drives the explorer folders and the
  *  grouped "Selected Work" overview on about.tsx. */
-export type ProjectGroup = "hiworks" | "school";
+export type ProjectGroup = "hiworks" | "personal";
 
 export interface ProjectGroupInfo {
   id: ProjectGroup;
@@ -65,7 +65,7 @@ export interface Project {
 /** Folder/heading config for each project cluster, in display order. */
 export const projectGroups: ProjectGroupInfo[] = [
   { id: "hiworks", folder: "hiworks", label: l("Hiworks", "Hiworks") },
-  { id: "school", folder: "school", label: l("School", "학교") },
+  { id: "personal", folder: "personal", label: l("Personal", "개인") },
 ];
 
 export interface SkillGroup {
@@ -323,7 +323,7 @@ export const projects: Project[] = [
     wip: true,
   },
   {
-    group: "school",
+    group: "personal",
     file: "capstone.tsx",
     idx: "S1",
     ctx: l("School · UTS", "학교 · UTS"),
@@ -334,7 +334,7 @@ export const projects: Project[] = [
     wip: true,
   },
   {
-    group: "school",
+    group: "personal",
     file: "coursework-a.tsx",
     idx: "S2",
     ctx: l("School · UTS", "학교 · UTS"),
@@ -345,13 +345,24 @@ export const projects: Project[] = [
     wip: true,
   },
   {
-    group: "school",
+    group: "personal",
     file: "coursework-b.tsx",
     idx: "S3",
     ctx: l("School · UTS", "학교 · UTS"),
     title: l("Coursework B", "수업 프로젝트 B"),
     stack: ["Python", "NLP"],
     blurb: l("(Draft) Coursework project — to be filled in.", "(작성 예정) 수업 프로젝트 — 내용 채울 예정."),
+    metric: l("TBD", "작성 예정"),
+    wip: true,
+  },
+  {
+    group: "personal",
+    file: "side-project.tsx",
+    idx: "P1",
+    ctx: l("Personal", "개인"),
+    title: l("Personal Project", "개인 프로젝트"),
+    stack: ["React", "TypeScript"],
+    blurb: l("(Draft) A personal side project — to be filled in.", "(작성 예정) 개인 사이드 프로젝트 — 내용 채울 예정."),
     metric: l("TBD", "작성 예정"),
     wip: true,
   },

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -120,7 +120,7 @@ function Inner() {
   const t = useT();
   const [openTabs, setOpenTabs] = useState<string[]>([DEFAULT_TAB]);
   const [activeTab, setActiveTab] = useState<string>(DEFAULT_TAB);
-  const [expanded, setExpanded] = useState<Record<string, boolean>>({ hiworks: true, school: true });
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({ hiworks: true, personal: true });
   const [sidebarWidth, setSidebarWidth] = useState<number>(readStoredWidth);
   const draggingRef = useRef(false);
   const widthRef = useRef(sidebarWidth);


### PR DESCRIPTION
Broaden the second project cluster so it holds both academic and personal side projects. Rename the group school -> personal (folder + label), move the existing coursework placeholders under it (kept with a School·UTS ctx tag), and add a personal side-project placeholder.